### PR TITLE
feat: add batch timezone lookup functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,10 @@ jobs:
           pgbench -U postgres -d pgbench_test -c 10 -T 10 -f pgbench/tzf_tzname.sql 2>&1 | grep -E "tps|latency|number of"
           echo "Testing tzf_tzname_point function:"
           pgbench -U postgres -d pgbench_test -c 10 -T 10 -f pgbench/tzf_tzname_point.sql 2>&1 | grep -E "tps|latency|number of"
+          echo "Testing tzf_tzname_batch function:"
+          pgbench -U postgres -d pgbench_test -c 10 -T 10 -f pgbench/tzf_tzname_batch.sql 2>&1 | grep -E "tps|latency|number of"
+          echo "Testing tzf_tzname_batch_points function:"
+          pgbench -U postgres -d pgbench_test -c 10 -T 10 -f pgbench/tzf_tzname_batch_points.sql 2>&1 | grep -E "tps|latency|number of"
 
       - name: Build release package
         run: cargo pgrx package --pg-config $PG_CONFIG

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags",
 ]
@@ -2029,7 +2029,7 @@ checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "tzf"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "lazy_static",
  "pgrx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tzf"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [lib]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ test:
 	cargo pgrx test pg14
 	cargo pgrx test pg15
 	cargo pgrx test pg16
+	cargo pgrx test pg17
 
 install:
 	cargo pgrx install
@@ -15,3 +16,13 @@ run:
 
 schema:
 	cargo pgrx schema > sql/tzf.sql
+
+reinstall:
+	psql -d postgres -c "DROP EXTENSION IF EXISTS tzf CASCADE;"
+	psql -d postgres -c "CREATE EXTENSION tzf;"
+
+basic-examples: reinstall
+	psql -d postgres -f examples/query_a_coord.sql
+	psql -d postgres -f examples/query_a_batch_coords.sql
+	psql -d postgres -f examples/query_a_point.sql
+	psql -d postgres -f examples/query_a_batch_points.sql

--- a/examples/query_a_batch_coords.sql
+++ b/examples/query_a_batch_coords.sql
@@ -1,0 +1,6 @@
+SELECT unnest(
+    tzf_tzname_batch(
+    ARRAY[-74.0060, -118.2437, 139.6917],
+    ARRAY[40.7128, 34.0522, 35.6895]
+    )
+) AS timezones;

--- a/examples/query_a_batch_points.sql
+++ b/examples/query_a_batch_points.sql
@@ -1,0 +1,9 @@
+SELECT unnest(
+    tzf_tzname_batch_points(
+    ARRAY[
+            point(-74.0060, 40.7128),
+            point(-118.2437, 34.0522),
+            point(139.6917, 35.6895)
+    ]
+    )
+) AS timezones;

--- a/examples/query_a_coord.sql
+++ b/examples/query_a_coord.sql
@@ -1,0 +1,1 @@
+SELECT tzf_tzname(116.3883, 39.9289) AS timezone;

--- a/examples/query_a_point.sql
+++ b/examples/query_a_point.sql
@@ -1,0 +1,1 @@
+SELECT tzf_tzname_point(point(-74.0060, 40.7128)) AS timezone;

--- a/pgbench/tzf_tzname_batch.sql
+++ b/pgbench/tzf_tzname_batch.sql
@@ -1,0 +1,11 @@
+\set size 1000
+\set lon random(-180, 180)
+\set lat random(-90, 90)
+
+SELECT unnest(
+    tzf_tzname_batch(
+        array_agg(:lon),
+        array_agg(:lat)
+    )
+)
+FROM generate_series(1, :size); 

--- a/pgbench/tzf_tzname_batch_points.sql
+++ b/pgbench/tzf_tzname_batch_points.sql
@@ -1,0 +1,10 @@
+\set size 1000
+\set lon random(-180, 180)
+\set lat random(-90, 90)
+
+SELECT unnest(
+    tzf_tzname_batch_points(
+        array_agg(point(:lon, :lat))
+    )
+)
+FROM generate_series(1, :size); 

--- a/sql/tzf.sql
+++ b/sql/tzf.sql
@@ -19,6 +19,29 @@ AS 'MODULE_PATHNAME', 'tzf_tzname_wrapper';
 /* </end connected objects> */
 
 /* <begin connected objects> */
+-- src/lib.rs:24
+-- tzf::tzf_tzname_batch
+CREATE  FUNCTION "tzf_tzname_batch"(
+	"lons" double precision[], /* alloc::vec::Vec<f64> */
+	"lats" double precision[] /* alloc::vec::Vec<f64> */
+) RETURNS TEXT[] /* alloc::vec::Vec<alloc::string::String> */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'tzf_tzname_batch_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- src/lib.rs:36
+-- tzf::tzf_tzname_batch_points
+CREATE  FUNCTION "tzf_tzname_batch_points"(
+	"points" point[] /* alloc::vec::Vec<pgrx_pg_sys::include::pg15::Point> */
+) RETURNS TEXT[] /* alloc::vec::Vec<alloc::string::String> */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'tzf_tzname_batch_points_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
 -- src/lib.rs:17
 -- tzf::tzf_tzname_point
 CREATE  FUNCTION "tzf_tzname_point"(


### PR DESCRIPTION
- Add tzf_tzname_batch to process arrays of coordinates
- Add tzf_tzname_batch_points to process arrays of points
- Add comprehensive test cases for batch operations
- Optimize performance by reducing PostgreSQL <-> Rust boundary crossings
- Support parallel execution with IMMUTABLE PARALLEL SAFE

This change improves performance when processing multiple coordinates by
reducing function call overhead between PostgreSQL and Rust. The batch
functions return timezone names directly, maintaining the same output
format as the single-point lookup functions.