### PR TITLE
Update pgrx version management and standardize multi-PG packaging workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,18 @@ jobs:
         with:
           components: rustfmt, clippy
 
+      - name: Detect pgrx version
+        id: pgrx_version
+        run: |
+          pgrx_version="$(sed -nE 's/^[[:space:]]*pgrx[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Cargo.toml | head -n1)"
+          if [ -z "$pgrx_version" ]; then
+            echo "failed to detect pgrx version from Cargo.toml" >&2
+            exit 1
+          fi
+          echo "version=$pgrx_version" >> "$GITHUB_OUTPUT"
+
       - name: Install pgrx
-        run: cargo install --locked cargo-pgrx
+        run: cargo install --locked cargo-pgrx --version "${{ steps.pgrx_version.outputs.version }}"
 
       - name: Install PostgreSQL ${{ matrix.pg_version }}
         run: |
@@ -79,7 +89,7 @@ jobs:
           echo "PG${{ matrix.pg_version }} path: $PG${{ matrix.pg_version }}"
 
           # Initialize pgrx with explicit pg_config path
-          cargo pgrx init --pg${{ matrix.pg_version }}=$PG${{ matrix.pg_version }}
+          ./scripts/pgrxw.sh init --pg${{ matrix.pg_version }}=$PG${{ matrix.pg_version }}
 
           # Check the config file that was created
           echo "Generated pgrx config:"
@@ -87,10 +97,10 @@ jobs:
 
       - name: Run tests
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: cargo pgrx test --release pg${{ matrix.pg_version }}
+        run: ./scripts/pgrxw.sh test --release pg${{ matrix.pg_version }}
 
       - name: Run install
-        run: cargo pgrx install --release --pg-config $PG_CONFIG
+        run: ./scripts/pgrxw.sh install --release --pg-config $PG_CONFIG
 
       - name: Run pgbench
         if: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -107,7 +117,7 @@ jobs:
           pgbench -U postgres -d pgbench_test -c 10 -T 10 -f pgbench/tzf_tzname_batch_points.sql 2>&1 | grep -E "tps|latency|number of"
 
       - name: Build release package
-        run: cargo pgrx package --pg-config $PG_CONFIG
+        run: ./scripts/pgrxw.sh package --pg-config $PG_CONFIG
 
       - name: Package artifacts
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
         id: pgrx_version
         run: |
           pgrx_version="$(sed -nE 's/^[[:space:]]*pgrx[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' Cargo.toml | head -n1)"
+          pgrx_version="${pgrx_version#=}"
           if [ -z "$pgrx_version" ]; then
             echo "failed to detect pgrx version from Cargo.toml" >&2
             exit 1
@@ -59,6 +60,16 @@ jobs:
           echo "PKG_CONFIG_PATH=/usr/lib/postgresql/${{ matrix.pg_version }}/lib/pkgconfig" >> $GITHUB_ENV
           echo "PG${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config" >> $GITHUB_ENV
           echo "PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config" >> $GITHUB_ENV
+
+      - name: Detect package metadata
+        id: package_meta
+        run: |
+          ext_version="$(sed -nE 's/^version = "([^"]+)".*/\1/p' Cargo.toml | head -n1)"
+          os_name="$(echo "${RUNNER_OS}" | tr '[:upper:]' '[:lower:]')"
+          arch_name="$(uname -m)"
+          tar_name="pg-tzf-v${ext_version}-pg${{ matrix.pg_version }}-${os_name}-${arch_name}.tar.gz"
+          echo "ext_version=$ext_version" >> "$GITHUB_OUTPUT"
+          echo "tar_name=$tar_name" >> "$GITHUB_OUTPUT"
 
       - name: Set proper directory permissions
         run: |
@@ -122,15 +133,22 @@ jobs:
       - name: Package artifacts
         run: |
           mkdir temp_package
-          find target/release/tzf-pg${{ matrix.pg_version }} \( -name "*.so" -o -name "*.sql" -o -name "*.control" \) -exec cp {} temp_package \;
-          tar czf pg-tzf${{ matrix.pg_version }}-linux.tar.gz -C temp_package .
+          find target/release/tzf-pg${{ matrix.pg_version }} -name "tzf.so" -exec cp {} temp_package \;
+          find target/release/tzf-pg${{ matrix.pg_version }} -name "tzf.control" -exec cp {} temp_package \;
+          find target/release/tzf-pg${{ matrix.pg_version }} -name "tzf--*.sql" -exec cp {} temp_package \;
+
+          test -f temp_package/tzf.so
+          test -f temp_package/tzf.control
+          ls temp_package/tzf--*.sql >/dev/null
+
+          tar czf "${{ steps.package_meta.outputs.tar_name }}" -C temp_package .
           rm -rf temp_package
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pg-tzf${{ matrix.pg_version }}-linux
-          path: pg-tzf${{ matrix.pg_version }}-linux.tar.gz
+          name: pg-tzf-pg${{ matrix.pg_version }}
+          path: ${{ steps.package_meta.outputs.tar_name }}
 
   publish:
     needs: test
@@ -147,6 +165,18 @@ jobs:
 
       - name: List artifacts
         run: find artifacts -type f
+
+      # This is the artifact aggregation gate for release.
+      # It verifies one tarball exists for every supported PG major version.
+      - name: Validate release artifacts
+        run: |
+          for pg in 14 15 16 17 18; do
+            count=$(find artifacts -type f -name "pg-tzf-v*-pg${pg}-*.tar.gz" | wc -l | tr -d '[:space:]')
+            if [ "$count" -lt 1 ]; then
+              echo "missing release tarball for pg${pg}" >&2
+              exit 1
+            fi
+          done
 
       - name: Create Release
         id: create_release

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 **/*.rs.bk
 tmp/
 docs/
-
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@
 /target
 *.iml
 **/*.rs.bk
-Cargo.lock
+tmp/
+docs/
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,25 +102,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bindgen"
-version = "0.71.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
-dependencies = [
- "annotate-snippets",
- "bitflags",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
@@ -1020,27 +1001,6 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdcfb88f7fa9ba42b4ea9d1f85a1d968bbb407cc30308b35f73bdfe6c966f64b"
-dependencies = [
- "bitflags",
- "bitvec",
- "enum-map",
- "libc",
- "pgrx-macros 0.16.1",
- "pgrx-pg-sys 0.16.1",
- "pgrx-sql-entity-graph 0.16.1",
- "seahash",
- "serde",
- "serde_cbor",
- "serde_json",
- "thiserror 2.0.17",
- "uuid",
-]
-
-[[package]]
-name = "pgrx"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd42eed31a68e3e6d7cec284cdaacd8ffa9b2b3ebb3f1df9ec2fd3558834c6e7"
@@ -1049,9 +1009,9 @@ dependencies = [
  "bitvec",
  "enum-map",
  "libc",
- "pgrx-macros 0.17.0",
- "pgrx-pg-sys 0.17.0",
- "pgrx-sql-entity-graph 0.17.0",
+ "pgrx-macros",
+ "pgrx-pg-sys",
+ "pgrx-sql-entity-graph",
  "seahash",
  "serde",
  "serde_cbor",
@@ -1062,52 +1022,21 @@ dependencies = [
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e35193b7e71e2f612d336cecd00db0f049f4cc609f2b1c9a34755b5ec559d7"
-dependencies = [
- "bindgen 0.71.1",
- "cc",
- "clang-sys",
- "eyre",
- "pgrx-pg-config 0.16.1",
- "proc-macro2",
- "quote",
- "regex",
- "shlex",
- "syn",
- "walkdir",
-]
-
-[[package]]
-name = "pgrx-bindgen"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d30fa3688ab1cb6429ca46725eb32d5d9f186806c0f0aa6419f86e418b8a81ab"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "clang-sys",
  "eyre",
- "pgrx-pg-config 0.17.0",
+ "pgrx-pg-config",
  "proc-macro2",
  "quote",
  "regex",
  "shlex",
  "syn",
  "walkdir",
-]
-
-[[package]]
-name = "pgrx-macros"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab542dd4041773874f90cd8e3448195749548dc3fb1daf501e7e11ebfb1dd22"
-dependencies = [
- "pgrx-sql-entity-graph 0.16.1",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1116,30 +1045,10 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ca7cc537daa4cc004f12ad1d31756b506358aa900251a82c3280e719da88fa4"
 dependencies = [
- "pgrx-sql-entity-graph 0.17.0",
+ "pgrx-sql-entity-graph",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "pgrx-pg-config"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff9b29df94c3f9fcb0cde220f92eea6975ed05962784a98fb557754ad663501"
-dependencies = [
- "cargo_toml",
- "codepage",
- "encoding_rs",
- "eyre",
- "owo-colors",
- "pathsearch",
- "serde",
- "serde_json",
- "thiserror 2.0.17",
- "toml",
- "url",
- "winapi",
 ]
 
 [[package]]
@@ -1164,46 +1073,16 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934f2536953ccb6722bef2cfdfb1f8d6d3cd4a4f2c508d56ec85b649c5680c2b"
-dependencies = [
- "cee-scape",
- "libc",
- "pgrx-bindgen 0.16.1",
- "pgrx-macros 0.16.1",
- "pgrx-sql-entity-graph 0.16.1",
- "serde",
-]
-
-[[package]]
-name = "pgrx-pg-sys"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f81faae87d533b573156261b17521c0c7f66f5ca5dab2b9e6ddbf5a63dbd14"
 dependencies = [
  "cee-scape",
  "libc",
- "pgrx-bindgen 0.17.0",
- "pgrx-macros 0.17.0",
- "pgrx-sql-entity-graph 0.17.0",
+ "pgrx-bindgen",
+ "pgrx-macros",
+ "pgrx-sql-entity-graph",
  "serde",
-]
-
-[[package]]
-name = "pgrx-sql-entity-graph"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07a767cb9faa612f1ba7f13718136d4006950d6f253b414ef487a03e85c47a94"
-dependencies = [
- "convert_case",
- "eyre",
- "petgraph 0.8.3",
- "proc-macro2",
- "quote",
- "syn",
- "thiserror 2.0.17",
- "unescape",
 ]
 
 [[package]]
@@ -1224,18 +1103,18 @@ dependencies = [
 
 [[package]]
 name = "pgrx-tests"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0d5d5f614a32310af2cc1b9587c69e041d97e8ab812d8d31fdcd3d33d27325c"
+checksum = "3d8026b55f3782cc227b32dcd1de61163b50175c98705d888f03e7095d371c41"
 dependencies = [
  "clap-cargo",
  "eyre",
  "libc",
  "owo-colors",
  "paste",
- "pgrx 0.16.1",
- "pgrx-macros 0.16.1",
- "pgrx-pg-config 0.16.1",
+ "pgrx",
+ "pgrx-macros",
+ "pgrx-pg-config",
  "postgres",
  "proptest",
  "rand",
@@ -1970,7 +1849,7 @@ name = "tzf"
 version = "0.2.4"
 dependencies = [
  "lazy_static",
- "pgrx 0.17.0",
+ "pgrx",
  "pgrx-tests",
  "tzf-rs",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ pgrx = "0.17.0"
 tzf-rs = "1.1.5"
 
 [dev-dependencies]
-pgrx-tests = "0.16.1"
+pgrx-tests = "0.17.0"
 
 [[bin]]
 name = "pgrx_embed_tzf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ sql-generator = true
 
 [features]
 default = []
-pg14 = ["pgrx/pg14"]
-pg15 = ["pgrx/pg15"]
-pg16 = ["pgrx/pg16"]
-pg17 = ["pgrx/pg17"]
-pg18 = ["pgrx/pg18"]
+pg14 = ["pgrx/pg14", "pgrx-tests/pg14"]
+pg15 = ["pgrx/pg15", "pgrx-tests/pg15"]
+pg16 = ["pgrx/pg16", "pgrx-tests/pg16"]
+pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
+pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = []
 
 [dependencies]
 lazy_static = "1.5.0"
-pgrx = "0.17.0"
+pgrx = "=0.17.0"
 tzf-rs = "1.1.5"
 
 [dev-dependencies]
-pgrx-tests = "0.17.0"
+pgrx-tests = "=0.17.0"
 
 [[bin]]
 name = "pgrx_embed_tzf"

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,23 @@
-PGRXW=./scripts/pgrxw.sh
+PGRXW := ./scripts/pgrxw.sh
+PG_VERSIONS := 14 15 16 17 18
+DIST_DIR := dist
+EXT_VERSION := $(shell sed -nE 's/^version = "([^"]+)".*/\1/p' Cargo.toml | head -n1)
+OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m)
 
-test:
-	$(PGRXW) test --release pg14
-	$(PGRXW) test --release pg15
-	$(PGRXW) test --release pg16
-	$(PGRXW) test --release pg17
-	$(PGRXW) test --release pg18
+.PHONY: test test-all test-pg% install clean run schema package package-all package-pg% clean-dist reinstall basic-examples
+
+test: test-all
+
+test-all:
+	@set -e; \
+	for pg in $(PG_VERSIONS); do \
+		echo "==> Running tests for pg$$pg"; \
+		$(PGRXW) test --release pg$$pg; \
+	done
+
+test-pg%:
+	$(PGRXW) test --release pg$*
 
 install:
 	$(PGRXW) install --release
@@ -13,14 +25,46 @@ install:
 clean:
 	cargo clean
 
+clean-dist:
+	rm -rf $(DIST_DIR)
+
 run:
 	$(PGRXW) run --release
 
 schema:
 	$(PGRXW) schema pg16 > sql/tzf.sql
 
-package:
-	$(PGRXW) package
+package: package-all
+
+package-all:
+	@mkdir -p $(DIST_DIR)
+	@set -e; \
+	for pg in $(PG_VERSIONS); do \
+		$(MAKE) package-pg$$pg; \
+	done
+
+package-pg%:
+	@set -e; \
+	mkdir -p "$(DIST_DIR)"; \
+	pg="$*"; \
+	pg_config="$$( $(PGRXW) info pg-config "$$pg" )"; \
+	out_dir="target/release/tzf-pg$$pg"; \
+	echo "==> Packaging pg$$pg with $$pg_config"; \
+	$(PGRXW) package --pg-config "$$pg_config" --out-dir "$$out_dir"; \
+	so_path="$$(find "$$out_dir" -type f -name 'tzf.so' | head -n1)"; \
+	control_path="$$(find "$$out_dir" -type f -name 'tzf.control' | head -n1)"; \
+	sql_path="$$(find "$$out_dir" -type f -name 'tzf--*.sql' | head -n1)"; \
+	test -n "$$so_path"; \
+	test -n "$$control_path"; \
+	test -n "$$sql_path"; \
+	archive="$(DIST_DIR)/pg-tzf-v$(EXT_VERSION)-pg$$pg-$(OS)-$(ARCH).tar.gz"; \
+	tmp_dir="$$(mktemp -d)"; \
+	cp "$$so_path" "$$tmp_dir/"; \
+	cp "$$control_path" "$$tmp_dir/"; \
+	cp "$$sql_path" "$$tmp_dir/"; \
+	tar czf "$$archive" -C "$$tmp_dir" .; \
+	rm -rf "$$tmp_dir"; \
+	echo "Created $$archive"
 
 reinstall:
 	psql -d postgres -c "DROP EXTENSION IF EXISTS tzf CASCADE;"

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,26 @@
+PGRXW=./scripts/pgrxw.sh
+
 test:
-	cargo pgrx test --release pg14
-	cargo pgrx test --release pg15
-	cargo pgrx test --release pg16
-	cargo pgrx test --release pg17
-	cargo pgrx test --release pg18
+	$(PGRXW) test --release pg14
+	$(PGRXW) test --release pg15
+	$(PGRXW) test --release pg16
+	$(PGRXW) test --release pg17
+	$(PGRXW) test --release pg18
 
 install:
-	cargo pgrx install --release
+	$(PGRXW) install --release
 
 clean:
 	cargo clean
 
 run:
-	cargo pgrx run --release
+	$(PGRXW) run --release
 
 schema:
-	cargo pgrx schema pg16 > sql/tzf.sql
+	$(PGRXW) schema pg16 > sql/tzf.sql
 
 package:
-	cargo pgrx package
+	$(PGRXW) package
 
 reinstall:
 	psql -d postgres -c "DROP EXTENSION IF EXISTS tzf CASCADE;"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 ## Installation from source
 
+`pg-tzf` multi-version support means one source tree builds multiple version-specific artifacts.
+Each PostgreSQL major version needs its own compiled extension package.
+
 ### Prerequisites
 
 - Rust
@@ -37,7 +40,37 @@ cargo install --locked cargo-pgrx --version {version}
    ```bash
    ./scripts/pgrxw.sh install
    ```
-3. Use in PostgreSQL:
+
+   Build for a specific PostgreSQL major version:
+
+   ```bash
+   ./scripts/pgrxw.sh install --release --features pg15 --no-default-features
+   ```
+
+3. Run tests for all supported PostgreSQL versions:
+
+   ```bash
+   make test-all
+   ```
+
+4. Build release tarballs for all supported PostgreSQL versions:
+
+   ```bash
+   make package-all
+   ```
+
+   Artifacts are generated under `dist/` with naming:
+
+   ```text
+   pg-tzf-v{ext_version}-pg{major}-{os}-{arch}.tar.gz
+   ```
+
+5. Retry packaging for one PostgreSQL major version:
+
+   ```bash
+   make package-pg15
+   ```
+6. Use in PostgreSQL:
    ```sql
    -- If you install old version of extension, you can drop it and install the new one.
    -- DROP EXTENSION tzf CASCADE;

--- a/README.md
+++ b/README.md
@@ -6,20 +6,24 @@
 
 - Rust
 - Cargo
-- PostgreSQL development headers (version 14, 14, 15, 16, 17, 18)
+- PostgreSQL development headers (version 14, 15, 16, 17, 18)
 - [cargo-pgrx](https://github.com/pgcentralfoundation/pgrx), version should be
   same as [`Cargo.toml`](Cargo.toml)
 
 ### Installing cargo-pgrx
 
 ```bash
-# Please see [Cargo.toml](Cargo.toml) for the version of cargo-pgrx.
-cargo install cargo-pgrx --version={version}
+# Auto-check pgrx and pgrx-tests version consistency, auto-sync cargo-pgrx,
+# then run cargo pgrx.
+./scripts/pgrxw.sh --help
+
+# Or install manually with the exact version from Cargo.toml.
+cargo install --locked cargo-pgrx --version {version}
 
 # Please note that you may need to init for your real PostgreSQL version.
 # For example, if you are using PostgreSQL 15 on macOS and install it via Homebrew:
-# you may need to run `cargo pgrx init --pg15 "$(brew --prefix postgresql@15)/bin/pg_config"`.
-cargo pgrx init
+# you may need to run `./scripts/pgrxw.sh init --pg15 "$(brew --prefix postgresql@15)/bin/pg_config"`.
+./scripts/pgrxw.sh init
 ```
 
 ### Build and install
@@ -31,7 +35,7 @@ cargo pgrx init
    ```
 2. Build and install the extension:
    ```bash
-   cargo pgrx install
+   ./scripts/pgrxw.sh install
    ```
 3. Use in PostgreSQL:
    ```sql

--- a/scripts/pgrxw.sh
+++ b/scripts/pgrxw.sh
@@ -7,7 +7,7 @@ if [[ ! -f Cargo.toml ]]; then
 fi
 
 # Keep cargo-pgrx exactly aligned with the pgrx crate declared in [dependencies].
-want_version="$({
+want_req="$({
   awk '
     /^\[dependencies\]$/ { in_deps = 1; next }
     /^\[/ { in_deps = 0 }
@@ -15,12 +15,14 @@ want_version="$({
   ' Cargo.toml
 } | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/; s/^[^"]*"([^"]+)".*/\1/')"
 
+want_version="${want_req#=}"
+
 if [[ -z "${want_version}" ]]; then
   echo "error: failed to parse pgrx version from Cargo.toml" >&2
   exit 1
 fi
 
-tests_version="$({
+tests_req="$({
   awk '
     /^\[dev-dependencies\]$/ { in_dev_deps = 1; next }
     /^\[/ { in_dev_deps = 0 }
@@ -28,8 +30,10 @@ tests_version="$({
   ' Cargo.toml
 } | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/; s/^[^"]*"([^"]+)".*/\1/')"
 
+tests_version="${tests_req#=}"
+
 if [[ -n "${tests_version}" && "${tests_version}" != "${want_version}" ]]; then
-  echo "error: pgrx-tests (${tests_version}) must match pgrx (${want_version})" >&2
+  echo "error: pgrx-tests (${tests_req}) must match pgrx (${want_req})" >&2
   exit 1
 fi
 

--- a/scripts/pgrxw.sh
+++ b/scripts/pgrxw.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ! -f Cargo.toml ]]; then
+  echo "error: Cargo.toml was not found in $(pwd)" >&2
+  exit 1
+fi
+
+# Keep cargo-pgrx exactly aligned with the pgrx crate declared in [dependencies].
+want_version="$({
+  awk '
+    /^\[dependencies\]$/ { in_deps = 1; next }
+    /^\[/ { in_deps = 0 }
+    in_deps && /^[[:space:]]*pgrx[[:space:]]*=/ { print; exit }
+  ' Cargo.toml
+} | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/; s/^[^"]*"([^"]+)".*/\1/')"
+
+if [[ -z "${want_version}" ]]; then
+  echo "error: failed to parse pgrx version from Cargo.toml" >&2
+  exit 1
+fi
+
+tests_version="$({
+  awk '
+    /^\[dev-dependencies\]$/ { in_dev_deps = 1; next }
+    /^\[/ { in_dev_deps = 0 }
+    in_dev_deps && /^[[:space:]]*pgrx-tests[[:space:]]*=/ { print; exit }
+  ' Cargo.toml
+} | sed -E 's/.*version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/; s/^[^"]*"([^"]+)".*/\1/')"
+
+if [[ -n "${tests_version}" && "${tests_version}" != "${want_version}" ]]; then
+  echo "error: pgrx-tests (${tests_version}) must match pgrx (${want_version})" >&2
+  exit 1
+fi
+
+have_version=""
+if cargo pgrx --version >/dev/null 2>&1; then
+  have_version="$(cargo pgrx --version | awk '{ print $2 }')"
+fi
+
+if [[ "${have_version}" != "${want_version}" ]]; then
+  echo "sync: installing cargo-pgrx ${want_version} (current: ${have_version:-none})" >&2
+  cargo install --locked cargo-pgrx --version "${want_version}"
+fi
+
+exec cargo pgrx "$@"


### PR DESCRIPTION
## Summary
- Add `scripts/pgrxw.sh` to enforce `cargo-pgrx` version alignment with `Cargo.toml` and validate `pgrx`/`pgrx-tests` consistency
- Pin `pgrx` and `pgrx-tests` to `=0.17.0` and map `pg14` to `pg18` features to both `pgrx` and `pgrx-tests`
- Refactor `Makefile` with `test-all`, `test-pg%`, `package-all`, and `package-pg%` targets, plus standardized artifact naming and smoke checks
- Enhance CI to detect pinned pgrx version, use wrapper-based pgrx commands, generate metadata-rich artifact names, and validate release artifact completeness across PG14 to PG18
- Update docs with the multi-artifact compatibility model and add a release runbook in `RELEASING.md`
- Update `.gitignore` to ignore `tmp/`, `docs/`, and `dist/`

## Testing
- `cargo metadata --no-deps --format-version 1`
- `./scripts/pgrxw.sh --help`
- `make test-pg15`
- `make package-pg15`